### PR TITLE
Added extra position field "entryPrice"

### DIFF
--- a/db/migrations/1698844323915-Data.js
+++ b/db/migrations/1698844323915-Data.js
@@ -8,7 +8,7 @@ module.exports = class Data1698844323915 {
             await db.query('BEGIN');
             await db.query('ALTER TABLE "position" ADD "entry_price" numeric;');
             await db.query('UPDATE "position" SET entry_price = price;');
-            await db.query('ALTER TABLE "position" ALTER COLUMN ventry_price SET NOT NULL;');
+            await db.query('ALTER TABLE "position" ALTER COLUMN entry_price SET NOT NULL;');
 
             await db.commitTransaction();
         } catch (error) {

--- a/db/migrations/1698844323915-Data.js
+++ b/db/migrations/1698844323915-Data.js
@@ -1,0 +1,23 @@
+module.exports = class Data1698844323915 {
+    name = 'Data1698844323915'
+
+    async up(db) {
+        try {
+            await db.startTransaction();
+
+            await db.query('BEGIN');
+            await db.query('ALTER TABLE "position" ADD "entry_price" numeric;');
+            await db.query('UPDATE "position" SET entry_price = price;');
+            await db.query('ALTER TABLE "position" ALTER COLUMN ventry_price SET NOT NULL;');
+
+            await db.commitTransaction();
+        } catch (error) {
+            await db.rollbackTransaction();
+            throw error;
+        }
+    }
+
+    async down(db) {
+        await db.query(`ALTER TABLE "position" DROP COLUMN "entry_price"`)
+    }
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -31,6 +31,7 @@ type Order @entity {
     id: ID! @unique @index
     market: Market!
     price: BigInt!
+	entryPrice: BigInt!
     quantity: BigInt!
     side: OrderSide!
     who: String

--- a/src/eventprocessor/market/postionCreatedEventProcessor.ts
+++ b/src/eventprocessor/market/postionCreatedEventProcessor.ts
@@ -29,7 +29,8 @@ export class PositionCreatedEventProcessor implements EventProcessor{
                     timestamp: new Date(block.header.timestamp),
                     status: PositionStatus.OPEN,
                     quantityLeft: BigInt(parsedEvent.quantity),
-                    price: parsedEvent.price // temporary - set in the next event
+                    price: parsedEvent.price, // temporary - set in the next event
+                    entryPrice: parsedEvent.price,
                 })
                 const delta = position.quantityLeft
                 await LiquidationPriceCalculator.calculate(position, ctx.store, delta)

--- a/src/model/generated/position.model.ts
+++ b/src/model/generated/position.model.ts
@@ -17,6 +17,9 @@ export class Position {
     market!: Market
 
     @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: false})
+    entryPrice!: bigint
+
+    @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: false})
     price!: bigint
 
     @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: false})


### PR DESCRIPTION
I spend some time preparing tests for this with some success but not ready yet.


query:

```query LatestPositionsOnGivenMarket {
  positions(where: {market: {id_eq: "9223372036854775809"}}, limit: 10, orderBy: timestamp_DESC) {
    id
    price
    timestamp
    quantity
    long
    short
    status
    entryPrice
  }
}
```

